### PR TITLE
Add scraped page archiver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 ruby '2.0.0'
 
-gem 'scraperwiki', github: 'https://github.com/openaustralia/scraperwiki-ruby',
+gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby',
                    branch: 'morph_defaults'
 gem 'execjs'
 gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,11 @@
 # Find out more: https://morph.io/documentation/ruby
 
 source 'https://rubygems.org'
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 ruby '2.0.0'
 
-gem 'scraperwiki', git: 'https://github.com/openaustralia/scraperwiki-ruby.git',
+gem 'scraperwiki', github: 'https://github.com/openaustralia/scraperwiki-ruby',
                    branch: 'morph_defaults'
 gem 'execjs'
 gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,4 @@ gem "nokogiri"
 gem "open-uri-cached"
 gem "fuzzy_match"
 gem 'yajl-ruby', require: 'yajl'
-
+gem 'scraped_page_archive'

--- a/Gemfile
+++ b/Gemfile
@@ -2,16 +2,17 @@
 # specified here will be installed and made available to your morph.io scraper.
 # Find out more: https://morph.io/documentation/ruby
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-ruby "2.0.0"
+ruby '2.0.0'
 
-gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby.git", branch: "morph_defaults"
-gem "execjs"
-gem "pry"
-gem "colorize"
-gem "nokogiri"
-gem "open-uri-cached"
-gem "fuzzy_match"
+gem 'scraperwiki', git: 'https://github.com/openaustralia/scraperwiki-ruby.git',
+                   branch: 'morph_defaults'
+gem 'execjs'
+gem 'pry'
+gem 'colorize'
+gem 'nokogiri'
+gem 'open-uri-cached'
+gem 'fuzzy_match'
 gem 'yajl-ruby', require: 'yajl'
 gem 'scraped_page_archive'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,16 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     coderay (1.1.0)
     colorize (0.7.7)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     execjs (2.5.2)
     fuzzy_match (2.1.0)
+    git (1.3.0)
+    hashdiff (0.3.0)
     httpclient (2.6.0.1)
     method_source (0.8.2)
     mini_portile (0.6.2)
@@ -24,10 +30,23 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    public_suffix (2.0.4)
+    safe_yaml (1.0.4)
+    scraped_page_archive (0.5.0)
+      git (~> 1.3.0)
+      vcr-archive (~> 0.3.0)
     slop (3.6.0)
     sqlite3 (1.3.10)
     sqlite_magic (0.0.3)
       sqlite3
+    vcr (3.0.3)
+    vcr-archive (0.3.0)
+      vcr (~> 3.0.2)
+      webmock (~> 2.0.3)
+    webmock (2.0.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     yajl-ruby (1.2.1)
 
 PLATFORMS
@@ -40,5 +59,12 @@ DEPENDENCIES
   nokogiri
   open-uri-cached
   pry
+  scraped_page_archive
   scraperwiki!
   yajl-ruby
+
+RUBY VERSION
+   ruby 2.0.0p648
+
+BUNDLED WITH
+   1.13.5

--- a/scraper.rb
+++ b/scraper.rb
@@ -5,8 +5,9 @@ require 'scraperwiki'
 require 'nokogiri'
 require 'colorize'
 require 'pry'
-require 'open-uri/cached'
-OpenURI::Cache.cache_path = '.cache'
+# require 'open-uri/cached'
+# OpenURI::Cache.cache_path = '.cache'
+require 'scraped_page_archive/open-uri'
 
 @ConstituencyRegion = {}
 


### PR DESCRIPTION
## What does this do?

Uses scraped-page-archive to archive all pages scraped.

## Why is this needed?

There's no specific urgency on this as there isn't an election until 2021, but the goal is to add this to all scrapers eventually.

## Relevant Issue(s):

n/a

## [Scraper Change checklist](https://github.com/everypolitician/everypolitician/wiki/Scraper-Change-checklist)
* [ ] 1. scraper is on Morph.io under the "everypolitician-scrapers" group? — no, it's still at https://morph.io/tmtmtmtm/welsh-assembly, but we can move it separately later
* [x] 2. scraper's GitHub "Website" link points at morph.io page?
* [x] 3. scraper is set to auto-run?
* [x] 4. scraper is archiving? — that's what this is doing!
* [x] 5. legislature has a scraper webhook set? -- on https://morph.io/tmtmtmtm/wales-AMs-wikidata

## [Adding Archiving to Scraper checklist](https://github.com/everypolitician/everypolitician/wiki/Adding-Archiving-to-Scraper-checklist)
* [x] 1. we are using at least version 0.5 of scraped-page-archive-gem?
* [x] 2. scraper uses scraped-page-archive gem directly or via a suitable strategy? — directly
* [ ] 3. MORPH_SCRAPER_CACHE_GITHUB_REPO_URL is configured? — @tmtmtmtm The scraper's ENV variables need configuring on Morph
* [x] 4. pages are being archived in new branch of correct scraper repo?

## [Gemfile checklist](https://github.com/everypolitician/everypolitician/wiki/Gemfile-checklist/)
* [x] 1. all links are secure
* [x] 2. links to Github use `github:` protocol, not simply `git:`
* [x] 3. formatting is consistent with our normal Rubocop setup
